### PR TITLE
add respirator support

### DIFF
--- a/ZScript/LTLGrenade/GasGrenade_Projectile.zsc
+++ b/ZScript/LTLGrenade/GasGrenade_Projectile.zsc
@@ -32,7 +32,11 @@ class HD_PBGasEmit:HDPuff{
             while (itr.next()) {
                 let next = itr.thing;
                 if (next.bKILLED)
-                    continue; 
+                    continue;
+				string checker = "uas_respirator_worn";
+				let rrr = next.findinventory(checker);
+				if(rrr)
+					continue;
 				if (next.countinv("WornRadsuit"))
                     continue; 
 				if (next.bNOBLOOD)


### PR DESCRIPTION
a small, non-mod dependent check that allows for PB toxic gas to tell if the player is wearing a UAS respirator. This push is being made in tandem with one for UAS that adds the aforementioned tokens.