### PR TITLE
Zerk check fix

### DIFF
--- a/ZScript/Melee/HDChargeFist.zsc
+++ b/ZScript/Melee/HDChargeFist.zsc
@@ -220,18 +220,18 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 			angle,pitch);*/
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDCFistPuff":"HDCFistPuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDCFistPuff":"HDCFistPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 		);
@@ -318,8 +318,8 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
 		else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDCFistPuff":"HDCFistPuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDCFistPuff":"HDCFistPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 
@@ -340,7 +340,7 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_StartSound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("PowerStrength");
+		bool kzk=kicker.countinv("HDZerk");
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -384,7 +384,7 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
 		FAX0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		FAX0 A 0;
 		FAX0 B 3;
@@ -432,7 +432,7 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
 		FAX0 A 0 A_StartSound("weapons/axeswing",CHAN_7);
 		FAX0 DE 1
 		{
@@ -534,7 +534,7 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("PowerStrength"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk"))A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -562,7 +562,7 @@ class HDChargeFist:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("PowerStrength"))A_SetTics(8);
+			if(countinv("HDZerk"))A_SetTics(8);
 		}
 		stop;
 	

--- a/ZScript/Melee/HDFireAxe.zsc
+++ b/ZScript/Melee/HDFireAxe.zsc
@@ -26,8 +26,7 @@ class HDAxePuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		// this doesn't actually do anything
-		//fadeafter=frandom(0,1);
+		fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("gray",
@@ -219,7 +218,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchAxe(double dmg){
+	action void HDPunchAxe(int dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,70,pitch,
@@ -233,18 +232,18 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 			angle,pitch);
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -276,7 +275,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 
 		//shit happens
 		//dmg*=frandom(0.85,1.5);
-		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.85,1.5)));
+		HDBleedingWound.inflict(punchee,dmg*frandom(0.85,1.5));
 
 
 		//other effects
@@ -336,11 +335,11 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		punchee.InStateSequence(curstate,resolvestate("falldown"));
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
-		else punchee.damagemobj(self,self,int(dmg*1.5),"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
+		else punchee.damagemobj(self,self,dmg*1.5,"SmallArms3");
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDAxePuff":"HDAxePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDAxePuff":"HDAxePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 
@@ -364,7 +363,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_PlaySound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("PowerStrength");
+		bool kzk=kicker.countinv("HDZerk");
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -415,7 +414,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
 		FAX0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		FAX0 A 0;
 		FAX0 B 3;
@@ -456,7 +455,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
 		FAX0 A 0 A_StartSound("weapons/axeswing",CHAN_7);
 		FAX0 DE 1;
 		#### D 0 A_Overlay(5,"hitcheck",false);
@@ -552,7 +551,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("PowerStrength"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk"))A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -580,7 +579,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("PowerStrength"))A_SetTics(8);
+			if(countinv("HDZerk"))A_SetTics(8);
 		}
 		stop;
 	

--- a/ZScript/Melee/HDFireAxe.zsc
+++ b/ZScript/Melee/HDFireAxe.zsc
@@ -26,7 +26,8 @@ class HDAxePuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		fadeafter=frandom(0,1);
+		// this doesn't actually do anything
+		//fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("gray",
@@ -218,7 +219,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchAxe(int dmg){
+	action void HDPunchAxe(double dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,70,pitch,
@@ -275,7 +276,7 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 
 		//shit happens
 		//dmg*=frandom(0.85,1.5);
-		HDBleedingWound.inflict(punchee,dmg*frandom(0.85,1.5));
+		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.85,1.5)));
 
 
 		//other effects
@@ -335,8 +336,8 @@ class HDFireAxe:HD_PB_UnarmedWeapon{
 		punchee.InStateSequence(curstate,resolvestate("falldown"));
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
-		else punchee.damagemobj(self,self,dmg*1.5,"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
+		else punchee.damagemobj(self,self,int(dmg*1.5),"SmallArms3");
 		
 		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
 			countinv("HDZerk")?"HDAxePuff":"HDAxePuff",

--- a/ZScript/Melee/HDKharon.zsc
+++ b/ZScript/Melee/HDKharon.zsc
@@ -20,8 +20,7 @@ class HDKharonPuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		// this doesn't actually do anything
-		//fadeafter=frandom(0,1);
+		fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("white",
@@ -260,7 +259,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchKharon(double dmg, int pb_angle=0, int pb_rotation=0,
+	action void HDPunchKharon(int dmg, int pb_angle=0, int pb_rotation=0, 
 							int pb_pitch=0,class<Actor> pb_pufftype="HDKharonSpark"){
 		flinetracedata punchline;
 		bool punchy=linetrace(
@@ -271,17 +270,17 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		);
 		
 		//actual puff effect if the shot connects
-		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"WallChunker":"WallChunker",
+		/*LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle+pb_angle,pb_range,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);*/
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -289,7 +288,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		
 		//pb_pufftype.roll=45;
 		
-		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle+pb_angle,75,pitch+pb_pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
 			"HDKharonPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
@@ -322,7 +321,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 
 		//shit happens
 		//dmg*=frandom(0.85,1.5);
-		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.85,1.5)));
+		HDBleedingWound.inflict(punchee,dmg*frandom(0.85,1.5));
 
 
 		//other effects
@@ -382,10 +381,10 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		punchee.InStateSequence(curstate,resolvestate("falldown"));
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
 			pb_pufftype,
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
@@ -555,7 +554,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 0;
 		KRN5 BCD 2;
 	startfire:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
 		KRN3 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		KRN3 FEDCBA 2;
 		KRN3 C 0 A_WeaponBusy;
@@ -576,7 +575,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		TNT1 A 2 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swinghard:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswinghard");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswinghard");
 		KRN3 BDF 1;
 		TNT1 A 6;
 		#### A 0 A_Overlay(5,"hitcheck",false);

--- a/ZScript/Melee/HDKharon.zsc
+++ b/ZScript/Melee/HDKharon.zsc
@@ -20,7 +20,8 @@ class HDKharonPuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		fadeafter=frandom(0,1);
+		// this doesn't actually do anything
+		//fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("white",
@@ -259,7 +260,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchKharon(int dmg, int pb_angle=0, int pb_rotation=0, 
+	action void HDPunchKharon(double dmg, int pb_angle=0, int pb_rotation=0,
 							int pb_pitch=0,class<Actor> pb_pufftype="HDKharonSpark"){
 		flinetracedata punchline;
 		bool punchy=linetrace(
@@ -321,7 +322,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 
 		//shit happens
 		//dmg*=frandom(0.85,1.5);
-		HDBleedingWound.inflict(punchee,dmg*frandom(0.85,1.5));
+		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.85,1.5)));
 
 
 		//other effects
@@ -381,7 +382,7 @@ class HDKharon:HD_PB_UnarmedWeapon{
 		punchee.InStateSequence(curstate,resolvestate("falldown"));
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
 		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",

--- a/ZScript/Melee/HDKnife.zsc
+++ b/ZScript/Melee/HDKnife.zsc
@@ -195,7 +195,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDStab(int dmg){
+	action void HDStab(double dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,54,pitch,
@@ -235,7 +235,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		}
 
 		//shit happens
-		HDBleedingWound.inflict(punchee,dmg*frandom(0.6,1.6));
+		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.6,1.6)));
 
 		//other effects
 		if(
@@ -278,7 +278,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 			A_Log(string.format("Punched %s for %i damage!",pch,dmg));
 		}
 		if(dmg*2>punchee.health)punchee.A_StartSound("misc/bulletflesh",CHAN_BODY);  
-		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms0");
+		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms0");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 
 		if(!punchee)invoker.targethealth=0;else{
@@ -342,7 +342,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		if(resisting){
 			vel+=(frandom(-1,1),frandom(-1,1),frandom(-1,1));
 			let grabbedmass=grabbed.mass;
-			if(random(grabbedmass*0.1,grabbedmass)>random(mass*0.6,mass*(zerk?5:1))){
+			if(frandom(grabbedmass*0.1,grabbedmass)>frandom(mass*0.6,mass*(zerk?5:1))){
 				vector2 thrustforce=(cos(angle),sin(angle))*frandom(0.,2.);
 				grabbed.vel.xy+=thrustforce*min(mass/grabbed.mass,1.);
 				vel.xy-=thrustforce;

--- a/ZScript/Melee/HDKnife.zsc
+++ b/ZScript/Melee/HDKnife.zsc
@@ -84,7 +84,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_PlaySound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("PowerStrength");
+		bool kzk=kicker.countinv("HDZerk");
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -195,7 +195,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDStab(double dmg){
+	action void HDStab(int dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,54,pitch,
@@ -206,8 +206,8 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		if(!punchy)return;
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,54,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"BulletPuffMedium":"BulletPuffSmall",
+		LineAttack(angle,54,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"BulletPuffMedium":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 		);
@@ -235,7 +235,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		}
 
 		//shit happens
-		HDBleedingWound.inflict(punchee,int(dmg*frandom(0.6,1.6)));
+		HDBleedingWound.inflict(punchee,dmg*frandom(0.6,1.6));
 
 		//other effects
 		if(
@@ -278,7 +278,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 			A_Log(string.format("Punched %s for %i damage!",pch,dmg));
 		}
 		if(dmg*2>punchee.health)punchee.A_StartSound("misc/bulletflesh",CHAN_BODY);  
-		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms0");
+		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms0");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 
 		if(!punchee)invoker.targethealth=0;else{
@@ -342,7 +342,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 		if(resisting){
 			vel+=(frandom(-1,1),frandom(-1,1),frandom(-1,1));
 			let grabbedmass=grabbed.mass;
-			if(frandom(grabbedmass*0.1,grabbedmass)>frandom(mass*0.6,mass*(zerk?5:1))){
+			if(random(grabbedmass*0.1,grabbedmass)>random(mass*0.6,mass*(zerk?5:1))){
 				vector2 thrustforce=(cos(angle),sin(angle))*frandom(0.,2.);
 				grabbed.vel.xy+=thrustforce*min(mass/grabbed.mass,1.);
 				vel.xy-=thrustforce;
@@ -451,7 +451,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	flick:
 		CKF0 A 1 offset(0,50) A_Lunge();
 		#### A 1 offset(0,36);
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"ZerkFlick");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"ZerkFlick");
 		#### AAAAAAA 0 A_CustomPunch((1),1,CPF_PULLIN,"HDFistPuncher",36);
 		goto flickend;
 	zerkflick:
@@ -465,7 +465,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	hold:
 	althold:
 	startfire:
-		CKF0 A 0 A_JumpIfInventory("PowerStrength",1,"zerkpunch");
+		CKF0 A 0 A_JumpIfInventory("HDZerk",1,"zerkpunch");
 		goto punch;
 	punch:
 		CKF0 C 1 A_WeaponReady(WRF_NOSWITCH|WRF_NOFIRE);
@@ -493,7 +493,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 	lunge:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("PowerStrength"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk"))A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 	kick:
@@ -502,7 +502,7 @@ class HDCombatKnife:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("PowerStrength"))A_SetTics(8);
+			if(countinv("HDZerk"))A_SetTics(8);
 		}
 		CKF0 A 0 A_Refire();
 		goto ready;

--- a/ZScript/Melee/HDPipeWrench.zsc
+++ b/ZScript/Melee/HDPipeWrench.zsc
@@ -93,13 +93,13 @@ class HDPipeWrench:HDWeapon{
 		if(!punchy)return;
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,60,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSmokeChunk":"BulletPuffBig",
+		LineAttack(angle,60,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffBig",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,60,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDPipeWrenchPuff":"HDPipeWrenchPuff",
+		LineAttack(angle,60,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDPipeWrenchPuff":"HDPipeWrenchPuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 		);
@@ -191,7 +191,7 @@ class HDPipeWrench:HDWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_StartSound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("PowerStrength");
+		bool kzk=kicker.countinv("HDZerk");
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -235,7 +235,7 @@ class HDPipeWrench:HDWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
 		PWR0 A 0 A_WeaponBusy();
 		PWR0 A 1 offset(2,36) A_ClearRefire();
 		PWR0 "#" 1 offset(3,38);
@@ -276,7 +276,7 @@ class HDPipeWrench:HDWeapon{
 		TNT1 A 2 A_StartSound("weapons/pocket",CHAN_6);
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
 		PWR0 A 0 A_StartSound("weapons/piepwrenchswing",CHAN_7);
 		PWR0 BC 1
 		{
@@ -379,7 +379,7 @@ class HDPipeWrench:HDWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("PowerStrength"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk"))A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -407,7 +407,7 @@ class HDPipeWrench:HDWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("PowerStrength"))A_SetTics(8);
+			if(countinv("HDZerk"))A_SetTics(8);
 		}
 		stop;
 	

--- a/ZScript/Melee/HDSledge.zsc
+++ b/ZScript/Melee/HDSledge.zsc
@@ -26,7 +26,8 @@ class HDSledgePuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		fadeafter=frandom(0,1);
+		// this doesn't actually do anything
+		//fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("gray",
@@ -218,7 +219,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchSledge(int dmg){
+	action void HDPunchSledge(double dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,70,pitch,
@@ -338,7 +339,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
 		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",

--- a/ZScript/Melee/HDSledge.zsc
+++ b/ZScript/Melee/HDSledge.zsc
@@ -26,8 +26,7 @@ class HDSledgePuff:HDBulletPuff{
 		A_ChangeVelocity(-0.4,0,frandom(0.1,0.4),CVF_RELATIVE);
 		trymove(pos.xy+vel.xy,false);
 		int stm=stamina;
-		// this doesn't actually do anything
-		//fadeafter=frandom(0,1);
+		fadeafter=frandom(0,1);
 		scale*=frandom(0.9,1.1);
 		for(int i=0;i<stamina;i++){
 			A_SpawnParticle("gray",
@@ -219,7 +218,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 			targethealth=0;
 		}
 	}
-	action void HDPunchSledge(double dmg){
+	action void HDPunchSledge(int dmg){
 		flinetracedata punchline;
 		bool punchy=linetrace(
 			angle,70,pitch,
@@ -235,18 +234,18 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		//setweaponstate("Whoops");
 
 		//actual puff effect if the shot connects
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"WallChunker":"WallChunker",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"WallChunker":"WallChunker",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 			
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSmokeChunk":"BulletPuffSmall",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSmokeChunk":"BulletPuffSmall",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSledgePuff":"HDSledgePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSledgePuff":"HDSledgePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12
 			
@@ -339,11 +338,11 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		
 		//punchee.InStateSequence(curstate,resolvestate("falldown"));
 		
-		if(punchee.health>0)punchee.damagemobj(self,self,int(dmg),"SmallArms3");
+		if(punchee.health>0)punchee.damagemobj(self,self,dmg,"SmallArms3");
 		//else HDF.Give(punchee,"SawGib",dmg*0.2);
 		
-		LineAttack(angle,70,pitch,punchline.hitline?(countinv("PowerStrength")?random(50,120):random(5,15)):0,"none",
-			countinv("PowerStrength")?"HDSledgePuff":"HDSledgePuff",
+		LineAttack(angle,70,pitch,punchline.hitline?(countinv("HDZerk")?random(50,120):random(5,15)):0,"none",
+			countinv("HDZerk")?"HDSledgePuff":"HDSledgePuff",
 			flags:LAF_NORANDOMPUFFZ|LAF_OVERRIDEZ,
 			offsetz:height-12);
 
@@ -367,7 +366,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	}
 	static void kick(actor kicker,actor kickee,actor kicking){
 		kickee.A_PlaySound("weapons/smack",CHAN_BODY);
-		bool kzk=kicker.countinv("PowerStrength");
+		bool kzk=kicker.countinv("HDZerk");
 		kickee.damagemobj(kicking,kicker,kzk?random(20,40):random(10,20),"bashing");
 		if(kickee&&!kickee.bnopain&&kickee.health>0&&random(0,4))kickee.setstatelabel("pain");
 		vector3 kickdir=(kickee.pos-kicker.pos).unit();
@@ -385,7 +384,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	droop:
 		TNT1 A 1{
 			if(pitch<frandom(5,8)&&(!gunbraced())){
-				if(countinv("IsMoving")>2 && countinv("PowerStrength")<1){    
+				if(countinv("IsMoving")>2 && countinv("HDZerk")<1){    
 					A_MuzzleClimb(frandom(-0.2,0.2),
 						frandom(0.1,clamp(1-pitch,0.1,0.3)));
 				}else{
@@ -447,7 +446,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	althold:
 		TNT1 A 0;
 	startfire:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswingstart");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswingstart");
 		SLH0 A 0 A_StartSound("weapons/pocket",CHAN_6);
 		//SLH0 A 0 A_WeaponBusy();
 		SLH0 B 3;
@@ -462,7 +461,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 		SLH0 D 2 offset(40,86);
 		TNT1 A 4 offset(-10,32);
 	bruh1:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"bruh2");
 		SLH0 EFGHIJKLMN 2 A_WeaponReady(WRF_NOFIRE|WRF_NOSWITCH);
 		SLH0 N 0 A_Overlay(3,"unf");
 		goto holdswing;
@@ -499,12 +498,12 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	swingreturn:
 		TNT1 A 7;
 		TNT1 A 5 A_StartSound("weapons/pocket",CHAN_6);
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"bruh2");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"bruh2");
 		SLH0 EFGHIJKLMN 2;
 		SLH0 N 0 A_Overlay(3,"unf");
 	goto holdswing;
 	swing:
-		#### A 0 A_JumpIfInventory("PowerStrength",1,"zerkswing");
+		#### A 0 A_JumpIfInventory("HDZerk",1,"zerkswing");
 		#### A 0 
 		{
 		if(hdplayerpawn(self))hdplayerpawn(self).fatigue+=5;
@@ -571,7 +570,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 	lunge2:
 		TNT1 A 0 A_Lunge();
 		TNT1 AA 1{
-			if(countinv("PowerStrength"))A_Recoil(-random(12,24));
+			if(countinv("HDZerk"))A_Recoil(-random(12,24));
 		}
 		TNT1 A 1 A_Recoil(-4);
 		stop;
@@ -599,7 +598,7 @@ class HDSledgehammer:HD_PB_UnarmedWeapon{
 			flinetracedata ktl;
 			LineTrace(angle,radius*1.6,0,offsetz:10,data:ktl);
 			if(ktl.hitactor)invoker.kick(self,ktl.hitactor,invoker);
-			if(countinv("PowerStrength"))A_SetTics(8);
+			if(countinv("HDZerk"))A_SetTics(8);
 		}
 		stop;
 	


### PR DESCRIPTION
Apparently, PowerStrength wasn't checked... at all, not to mention giving yourself PowerStrength automatically gets converted into HDZerk.
![Screenshot_2022-04-23-08-22-11-567_com opentouchgaming deltatouch](https://user-images.githubusercontent.com/90155229/164863267-907a7935-6bde-48f3-b6ac-01b481342921.jpg)
....hence why the melee weapons weren't as buffed as hell when you get zerked.